### PR TITLE
docs: update copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 New York University (Denis Pelli and the EasyEyes team)
+Copyright (c) 2026 New York University (Denis Pelli and the EasyEyes team)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- update the license copyright notice to 2026
- standardize ownership as New York University (Denis Pelli and the EasyEyes team)

## Verification

- verified the commit changes only the repository license file